### PR TITLE
Fix typo in exception message

### DIFF
--- a/pytest_postgresql/factories/process.py
+++ b/pytest_postgresql/factories/process.py
@@ -48,7 +48,7 @@ def _pg_exe(executable: Optional[str], config: PostgresqlConfigDict) -> str:
             ).strip()
         except FileNotFoundError as ex:
             raise ExecutableMissingException(
-                "Could not found pg_config executable. Is it in systenm $PATH?"
+                "Could not found pg_config executable. Is it in system $PATH?"
             ) from ex
         postgresql_ctl = os.path.join(pg_bindir, "pg_ctl")
     return postgresql_ctl


### PR DESCRIPTION
Chore that needs to be done:

* [ ] Add newsfragment `pipenv run towncrier create [issue_number].[type].rst`

Types are defined in the pyproject.toml, issue_number either from issue tracker or the Pull request number
